### PR TITLE
feat: added support for built-in public endpoints

### DIFF
--- a/.run/Dependencies.run.xml
+++ b/.run/Dependencies.run.xml
@@ -1,0 +1,11 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Dependencies" type="docker-deploy" factoryName="docker-compose.yml" server-name="Docker">
+    <deployment type="docker-compose.yml">
+      <settings>
+        <option name="envFilePath" value="" />
+        <option name="sourceFilePath" value="test/docker/docker-compose.yaml" />
+      </settings>
+    </deployment>
+    <method v="2" />
+  </configuration>
+</component>

--- a/README.md
+++ b/README.md
@@ -111,6 +111,33 @@ the `resource_access` claim will never go through and will fail the guard.
 
 > It is not possible to use `@RealmRoles()` and `@ResourceRoles()` on the same route.
 
+For public endpoints like `/health` or `/metrics` you can use the built-in public endpoints are used to keep these paths
+open. If you want to override these defaults or disable them, you can do so by configuring the `OidcProtectModule` using
+the `OidcProtectModuleBuilder`:
+
+```typescript
+@Module({
+  imports: [
+    config,
+    // ...other modules
+    new OidcProtectModuleBuilder()
+      .withConfig(config)
+      .noPublicEndpoints() // for disabling the built-in public endpoints
+      .overridePublicEndpoints(
+        [
+          '/health',
+          '/metrics',
+          '/healthz',
+        ],
+      )
+      .build(),
+  ],
+  // ... other provider, controllers etc.
+})
+export class AppModule {
+}
+```
+
 We hope you find this library useful in your NestJS projects!
 
 ## Development

--- a/src/library/builder/oidc-protect-module.builder.ts
+++ b/src/library/builder/oidc-protect-module.builder.ts
@@ -5,6 +5,19 @@ import { OidcProtectConfiguration } from "../config/oidc-protect.configuration";
 export class OidcProtectModuleBuilder extends BaseBuilder {
   requiredContext = ["library"];
 
+  private usePublicEndpoints = true;
+  private wellKnownPublicEndpoints = ["/health", "/metrics"];
+
+  public noPublicEndpoints(): this {
+    this.usePublicEndpoints = false;
+    return this;
+  }
+
+  public overridePublicEndpoints(endpoints: string[]): this {
+    this.wellKnownPublicEndpoints = endpoints;
+    return this;
+  }
+
   override build() {
     super.build();
 
@@ -18,6 +31,9 @@ export class OidcProtectModuleBuilder extends BaseBuilder {
       useFactory: (config: ConfigService<OidcProtectConfiguration>) => ({
         wellKnownUrl: config.schema.wellKnownUrl,
         resourceId: config.schema.resourceId,
+        wellKnownPublicEndpoints: this.usePublicEndpoints
+          ? this.wellKnownPublicEndpoints
+          : [],
       }),
     });
   }

--- a/src/library/guard/resource.guard.ts
+++ b/src/library/guard/resource.guard.ts
@@ -1,4 +1,9 @@
-import { CanActivate, ExecutionContext, Injectable } from "@nestjs/common";
+import {
+  CanActivate,
+  ExecutionContext,
+  HttpException,
+  Injectable,
+} from "@nestjs/common";
 import { InjectLogger, LoggerService } from "@flowcore/microservice";
 import { OidcProtectService } from "../oidc-protect/oidc-protect.service";
 import { Reflector } from "@nestjs/core";
@@ -34,6 +39,10 @@ export class ResourceGuard implements CanActivate {
     }
 
     const { headers } = await this.oidcProtect.extractRequest(context);
+
+    if (!headers.authorization) {
+      throw new HttpException("No authorization header found", 401);
+    }
 
     const { decodedToken } = this.oidcProtect.extractTokens(headers);
 

--- a/src/library/guard/role.guard.ts
+++ b/src/library/guard/role.guard.ts
@@ -1,4 +1,9 @@
-import { CanActivate, ExecutionContext, Injectable } from "@nestjs/common";
+import {
+  CanActivate,
+  ExecutionContext,
+  HttpException,
+  Injectable,
+} from "@nestjs/common";
 import { InjectLogger, LoggerService } from "@flowcore/microservice";
 import { OidcProtectService } from "../oidc-protect/oidc-protect.service";
 import { Reflector } from "@nestjs/core";
@@ -34,6 +39,10 @@ export class RoleGuard implements CanActivate {
     }
 
     const { headers } = await this.oidcProtect.extractRequest(context);
+
+    if (!headers.authorization) {
+      throw new HttpException("No authorization header found", 401);
+    }
 
     const { decodedToken } = this.oidcProtect.extractTokens(headers);
 

--- a/src/library/interface/oidc-protect-module-options.interface.ts
+++ b/src/library/interface/oidc-protect-module-options.interface.ts
@@ -1,4 +1,6 @@
 export interface OidcProtectModuleOptions {
   wellKnownUrl: string;
   resourceId?: string;
+
+  wellKnownPublicEndpoints?: string[];
 }

--- a/src/library/oidc-protect/oidc-protect.service.ts
+++ b/src/library/oidc-protect/oidc-protect.service.ts
@@ -38,6 +38,12 @@ export class OidcProtectService implements OnApplicationBootstrap {
     }
   }
 
+  public isPublicEndpoint(endpoint: string) {
+    const { wellKnownPublicEndpoints } = this.options.get();
+
+    return wellKnownPublicEndpoints?.includes(endpoint);
+  }
+
   async onApplicationBootstrap() {
     const { wellKnownUrl, resourceId } = this.options.get();
 
@@ -84,9 +90,6 @@ export class OidcProtectService implements OnApplicationBootstrap {
 
     const { headers } = request;
 
-    if (!headers.authorization) {
-      throw new HttpException("No authorization header found", 401);
-    }
     return { request, headers };
   }
 

--- a/test/fixtures/wellknown.controller.ts
+++ b/test/fixtures/wellknown.controller.ts
@@ -1,0 +1,19 @@
+import { Controller, Get } from "@nestjs/common";
+
+@Controller()
+export class WellKnownController {
+  @Get("/health")
+  public health(): string {
+    return "ok";
+  }
+
+  @Get("/metrics")
+  public metrics(): string {
+    return "ok";
+  }
+
+  @Get("/not-known")
+  public notKnown(): string {
+    return "ok";
+  }
+}

--- a/test/oidc-protect.module.spec.ts
+++ b/test/oidc-protect.module.spec.ts
@@ -23,6 +23,7 @@ import {
 import { DocumentNode, print } from "graphql/language";
 import gql from "graphql-tag";
 import * as path from "path";
+import { WellKnownController } from "./fixtures/wellknown.controller";
 
 const config = ConfigModule.forRoot(
   new ConfigFactory().withSchema(OidcProtectConfigurationSchema),
@@ -45,6 +46,7 @@ const config = ConfigModule.forRoot(
       }),
     }),
   ],
+  controllers: [WellKnownController],
   providers: [
     TestResolver,
     ...new AuthGuardBuilder().usingRoleGuard().usingResourceGuard().build(),
@@ -134,7 +136,7 @@ describe("OIDC Protect Module", () => {
     expect(response.body.data.test).toBe("test");
   });
 
-  it("should pass for public operation", async () => {
+  it("should pass for public decorated endpoints", async () => {
     const response = await queryGraphQLEndpoint(
       app,
       gql`
@@ -145,6 +147,12 @@ describe("OIDC Protect Module", () => {
     );
 
     expect(response.body.data.public).toBe("public");
+  });
+
+  it("should pass for built-in public endpoints", async () => {
+    await supertest(app.getHttpServer()).get("/health").expect(200);
+    await supertest(app.getHttpServer()).get("/metrics").expect(200);
+    await supertest(app.getHttpServer()).get("/not-known").expect(401);
   });
 
   it("should return forbidden with no access to realm role", async () => {


### PR DESCRIPTION
Added support for built-in public endpoints that are useful when creating services with `/health` and `/metrics` endpoints. Can be turned off or overridden